### PR TITLE
Add a flag to print test output while parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-*.xml
 *.log
+*.txt
+*.xml
+
 .vscode
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ go2junit test -h
 
 ## Open points
 
+* Extend README with more examples (cover all cli arguments)
+* Add unit tests
 * Add reference data from diverse test runs of different projects
-* Handle non-trivial cases that might not be handled yet
-* Improve documentation

--- a/cmd/go2junit/main.go
+++ b/cmd/go2junit/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var version string = "v0.3.3"
+var version string = "v0.4.0"
 
 func main() {
 	app := cli.NewApp()
@@ -31,6 +31,11 @@ func main() {
 					Usage:   "write output to `FILE` (defaults to stdout if not set)",
 				},
 				&cli.BoolFlag{
+					Name:    "print",
+					Aliases: []string{"p"},
+					Usage:   "print test log to stdout, requires --output to be set or junit report will be discarded",
+				},
+				&cli.BoolFlag{
 					Name:  "fail",
 					Usage: "return with a non-zero exit status in the case a parsed test failed",
 				},
@@ -47,6 +52,11 @@ func main() {
 					Name:    "output",
 					Aliases: []string{"o"},
 					Usage:   "write output to `FILE` (defaults to stdout if not set)",
+				},
+				&cli.BoolFlag{
+					Name:    "print",
+					Aliases: []string{"p"},
+					Usage:   "print test log to stdout, requires --output to be set or junit report will be discarded",
 				},
 			},
 		},

--- a/cmd/go2junit/parser.go
+++ b/cmd/go2junit/parser.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fasmat/go2junit/types"
 )
 
-func parse(w io.Writer, r io.Reader, fail bool) {
+func parse(w io.Writer, r io.Reader, p io.Writer, fail bool) {
 	scanner := bufio.NewScanner(r)
 
 	// suites -> suite
@@ -50,6 +50,9 @@ func parse(w io.Writer, r io.Reader, fail bool) {
 			switch event.Action {
 			case "output":
 				suite.Systemout.Text += event.Output
+				if _, err := p.Write([]byte(event.Output)); err != nil {
+					log.Fatalf("error printing test package output: %v", err)
+				}
 				continue
 			case "fail":
 				testfailed = true
@@ -80,6 +83,9 @@ func parse(w io.Writer, r io.Reader, fail bool) {
 			continue
 		case "output":
 			testcase.Systemout.Text += event.Output
+			if _, err := p.Write([]byte(event.Output)); err != nil {
+				log.Fatalf("error printing test event output: %v", err)
+			}
 		case "pass":
 			testcase.TimeAttr = strconv.FormatFloat(event.Elapsed, 'f', 2, 64)
 		case "fail":

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require github.com/urfave/cli/v2 v2.3.0
 
 require (
-	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
-	github.com/russross/blackfriday/v2 v2.0.1 // indirect
-	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=


### PR DESCRIPTION
This implements the change described in https://github.com/fasmat/go2junit/issues/6.

Setting the `-p` / `-print` flag that prints the output of the test run to stdout while parsing.